### PR TITLE
Deploy Root Folders Feature

### DIFF
--- a/configs/default.task.proxy.map.yaml
+++ b/configs/default.task.proxy.map.yaml
@@ -50,10 +50,6 @@ watch:
   constructorLocation: ./bundle/task-proxies/WatchProxy
   helpInfo: ""
 
-prompt:
-  constructorLocation: ./task-proxies/PromptProxy
-  helpInfo: ""
-
 config:
   constructorLocation: ./task-proxies/ConfigProxy
   helpInfo: ""

--- a/configs/default.wrangler.config.yaml
+++ b/configs/default.wrangler.config.yaml
@@ -84,15 +84,6 @@ tasks:
     # Should files be linted before deploy
     lintBeforeDeploy: false
 
-    # Local deploy config used to override local bundle.wrangler.yaml deploy config options.
-    # Stored in `localConfigPath` whose default value is '.gulpw'
-    localDeployFileName: deploy.yaml
-
-    # Use one-to-one paths for undefined/null deploy paths.
-    # If this is false and an undefined/null deploy path is found for a type an error
-    # is thrown and the deploy tasks exits
-    useOneToOnePaths: false
-
     deployUsingUnixStylePaths: true
 
     # Options written by `gulpw deploy-config`
@@ -155,9 +146,6 @@ tasks:
 #        # example: sites/<%= hostnamePrefix %><%= hostname %> (recieves the `deploy` has from this config)
 #        deployRootFolder: null
 #
-#        # Whether or not to prepend deploy root folders:
-#        prependDeployRootFolder: true,
-#
 #        # Use deploy root folders by file type
 #        useDeployRootFoldersByFileType: false,
 #
@@ -167,15 +155,6 @@ tasks:
 #        #  jsp: ...
 #        #  php: ...
 #
-#        # Directories for deploying file types to specific paths within the selected {web-host}/[{web-host-prefix]
-#        # @todo change this to `deployRootFoldersByFileType`
-#        typesAndDeployPathsMap:
-#          font: public/media/fonts/
-#          html: public/
-#          video: public/media/videos/
-#          image: public/media/images/
-#          js: public/js/
-#          css: public/css/
 
 #  develop:
 #    tasks:

--- a/configs/default.wrangler.config.yaml
+++ b/configs/default.wrangler.config.yaml
@@ -10,9 +10,8 @@ localConfigPath: ./.gulpw
 localConfigBackupPath: ./.gulpw/backups
 
 staticTasks:
-  "prompt": {}
-  "deploy-config": {}
   "config": {}
+  "deploy-config": {}
   "bundle-config": {}
 
 tasks:

--- a/configs/default.wrangler.config.yaml
+++ b/configs/default.wrangler.config.yaml
@@ -158,9 +158,14 @@ tasks:
 #        # Whether or not to prepend deploy root folders:
 #        prependDeployRootFolder: true,
 #
+#        # Use deploy root folders by file type
+#        useDeployRootFoldersByFileType: false,
+#
 #        # Deploy roots by file types;  E.g., File types can have different deploy roots or can be deployed to
-#        # any directory within the remote servers file system via this hash map.
-#        deployRootFoldersByFileType: null
+#        # any directory within the remote server's file system via this hash map.
+#        #deployRootFoldersByFileType: null
+#        #  jsp: ...
+#        #  php: ...
 #
 #        # Directories for deploying file types to specific paths within the selected {web-host}/[{web-host-prefix]
 #        # @todo change this to `deployRootFoldersByFileType`

--- a/src/bundle/task-proxies/DeployProxy.js
+++ b/src/bundle/task-proxies/DeployProxy.js
@@ -210,7 +210,6 @@ module.exports = TaskProxy.extend(function DeployProxy (config) {
 
                 // Build deploy src path
                 if (self._serverEntryHasDeployFolderType(selectedServerEntry, fileType)) {
-
                     deployPath = path.join(selectedServerEntry.deployRootFoldersByFileType[fileType],
                         bundle.options.alias + '.' + fileType);
                 }
@@ -255,8 +254,7 @@ module.exports = TaskProxy.extend(function DeployProxy (config) {
         return Array.isArray(fileArray) ? fileArray.map(function (item) {
             var retVal;
             if (self._serverEntryHasDeployFolderType(selectedServerEntry, fileType)) {
-                retVal = [item, path.join(selectedServerEntry.deployRootFoldersByFileType[fileType],
-                                    path.basename(item))];
+                retVal = [item, path.join(selectedServerEntry.deployRootFoldersByFileType[fileType], item)];
             }
             else {
                 retVal = [item, path.join(selectedServerEntry.deployRootFolder || '', item)];
@@ -311,17 +309,19 @@ module.exports = TaskProxy.extend(function DeployProxy (config) {
                     lodash.template(selectedServerEntry.deployRootFolder, deployOptions);
         }
 
-        if (selectedServerEntry.deployRootFoldersByType) {
-            selectedServerEntry.deployRootFoldersByType =
-                selectedServerEntry.deployRootFoldersByType.map(function (entry) {
-                        return lodash.template(selectedServerEntry.deployRootFoldersByType[entry], deployOptions);
+        console.log(selectedServerEntry);
+
+        if (!sjl.empty(selectedServerEntry.deployRootFoldersByFileType)) {
+                Object.keys(selectedServerEntry.deployRootFoldersByFileType).forEach(function (key) {
+                        selectedServerEntry.deployRootFoldersByFileType[key] =
+                            lodash.template(selectedServerEntry.deployRootFoldersByFileType[key], deployOptions);
                     });
         }
         return this;
     },
 
     _serverEntryHasDeployFolderType: function (serverEntry, fileType) {
-        return sjl.classOfIs(serverEntry.deployRootFoldersByFileType) && serverEntry.deployRootFoldersByFileType[fileType];
+        return sjl.classOfIs(serverEntry.deployRootFoldersByFileType, 'Object') && serverEntry.deployRootFoldersByFileType[fileType];
     }
 
 }); // end of export

--- a/src/wrangler/Wrangler.js
+++ b/src/wrangler/Wrangler.js
@@ -49,6 +49,7 @@ module.exports = sjl.Extendable.extend(function Wrangler(gulp, argv, env, config
     self.taskKeys = Object.keys(self.tasks);
     self.staticTaskKeys = Object.keys(self.staticTasks);
 
+    // Preparing to give all gulpw components direct access to gulp and wrangler internally.
     self.gulp = gulp;
 
     // Initialize the pipeline call(s)
@@ -150,7 +151,7 @@ module.exports = sjl.Extendable.extend(function Wrangler(gulp, argv, env, config
         options.alias = task;
         options.help = self.taskProxyMap.help;
 
-        return new TaskProxyClass(options);
+        return new TaskProxyClass(options, gulp, this);
     },
 
     createStaticTaskProxy: function (gulp, task) {

--- a/src/wrangler/Wrangler.js
+++ b/src/wrangler/Wrangler.js
@@ -90,17 +90,17 @@ module.exports = sjl.Extendable.extend(function Wrangler(gulp, argv, env, config
 
             // If any global tasks to run create tasks proxies and all bundles.
             if (anyGlobalTasksToRun && !anyPerBundleTasksToRun) {
-                self.log('Global tasks found and no Per-Bundle tasks found.', '\n', 'Preparing global tasks.');
+                self.log('\nGlobal tasks found and no Per-Bundle tasks found.', '\n', 'Preparing global tasks.', '--debug');
                 self.createBundles(gulp, null, false);
                 self.registerGlobalTasks(gulp, argv._);
             }
             else if (anyGlobalTasksToRun && anyPerBundleTasksToRun) {
-                self.log('Global tasks found and Per-Bundle tasks found.', '\n', 'Preparing global and per-bundle tasks.');
+                self.log('\nGlobal tasks found and Per-Bundle tasks found.', '\n', 'Preparing global and per-bundle tasks.', '--debug');
                 self.createBundles(gulp, null, true);
                 self.registerGlobalTasks(gulp, argv._);
             }
             else if (anyPerBundleTasksToRun && !anyGlobalTasksToRun) {
-                self.log('No global tasks found but found Per-Bundle tasks.', '\n', 'Preparing per-bundle tasks.');
+                self.log('\nNo global tasks found but found Per-Bundle tasks.', '\n', 'Preparing per-bundle tasks.', '--debug');
                 self.createBundles(gulp, self.extractBundlePathsFromArgv(argv), true);
             }
         }
@@ -470,7 +470,6 @@ module.exports = sjl.Extendable.extend(function Wrangler(gulp, argv, env, config
         task = sjl.classOfIs(task, 'Object') ? task.alias : task;
         var self = this;
         if (!self.isTaskRegistered(bundle + ':' + task)) {
-            console.log(self.bundles[bundle]);
             self.tasks[task].instance.registerBundle(self.bundles[bundle], self.gulp, self);
         }
         return self;


### PR DESCRIPTION
Now you can prepend deploy paths for any particular file type using the `deployRootFoldersByType` hash inside of a server entry inside of `deploy.domainsToDevelop`!